### PR TITLE
add flags to entrypoint to allow MPI to run as root

### DIFF
--- a/docker/ubuntu
+++ b/docker/ubuntu
@@ -91,6 +91,8 @@ RUN . /opt/spack-environment/activate.sh && \
 RUN { \
       echo '#!/bin/sh' \
       && echo '.' /opt/spack-environment/activate.sh \
+      && echo export OMPI_ALLOW_RUN_AS_ROOT=1 \
+      && echo export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
       && echo 'exec "$@"'; \
     } > /entrypoint.sh \
 && chmod a+x /entrypoint.sh \


### PR DESCRIPTION
MPI calls throw an error when running as root, while the standard behavior in Docker is to run as root on login. This adds environment variables to the Docker entrypoint that disable that error and allow MPI to run as root.