### PR TITLE
fixup: correct syntax of the spack.yaml

### DIFF
--- a/docker/ubuntu
+++ b/docker/ubuntu
@@ -47,7 +47,8 @@ set -o noclobber \
 &&   echo '  concretizer:' \
 &&   echo '    unify: true' \
 &&   echo '  config:' \
-&&   echo '    install_tree: /opt/software' \
+&&   echo '    install_tree:' \
+&&   echo '      root: /opt/software' \
 &&   echo '  view: /opt/views/view') > /opt/spack-environment/spack.yaml
 
 # Find apt-get packages, then build the spack environment


### PR DESCRIPTION
This fixes a container build issue. It seems this format changed for the spack input.

Combined with [this spack PR](https://github.com/spack/spack-packages/pull/1687#pullrequestreview-3787547278) now being incorporated to the spack develop container and once [Myna PR #138](https://github.com/ORNL-MDF/Myna/pull/138) is merged, this _should_ get the container built (I've tested that it builds successfully locally) and successfully running the Myna CI (tests pass locally, but haven't run the exact Myna CI).